### PR TITLE
chore(add retrain button and collect data only first time)

### DIFF
--- a/src/app/collecting/collecting.component.ts
+++ b/src/app/collecting/collecting.component.ts
@@ -42,14 +42,21 @@ export class CollectingComponent implements OnInit, OnDestroy {
   ];
 
   ngOnInit(): void {
-    this.loader = document.querySelector("app-loader");
-    this.container = document.querySelector(".example-card");
-    this.showGatheringDataModal("Correct posture");
+    const modalFiles = localStorage.getItem("modal-files");
+    if (modalFiles) {
+      this.router.navigate(["/home"]);
+    } else {
+      this.loader = document.querySelector("app-loader");
+      this.container = document.querySelector(".example-card");
+      this.showGatheringDataModal("Correct posture");
+    }
   }
 
   ngOnDestroy(): void {
-    this.p5.remove();
-    this.video.remove();
+    if (this.p5 && this.video) {
+      this.p5.remove();
+      this.video.remove();
+    }
   }
 
   // This function is called from inIt() and this function calls the main setup() function
@@ -144,6 +151,7 @@ export class CollectingComponent implements OnInit, OnDestroy {
       const { ipcRenderer } = electron;
       ipcRenderer.once("files-created", () => {
         this.p5.remove();
+        localStorage.setItem("modal-files", "modal-files-created");
         this.goToHomePage();
       });
       ipcRenderer.send("create-model-files", data);

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -135,7 +135,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
 
     this.p5.pop();
 
-    if (this.postures) {
+    if (this.postures && label1) {
       // if postures are not empty then it will execute and looping the postures varaible
       this.postures.map(
         (data: {

--- a/src/app/shared/header/header.component.html
+++ b/src/app/shared/header/header.component.html
@@ -1,3 +1,10 @@
-<mat-toolbar color="primary">
+<mat-toolbar class="toolbar" color="primary">
   <h1>Posture Buddy</h1>
+  <button
+    mat-button
+    *ngIf="router.url == '/home'"
+    (click)="goToCollectingPage()"
+  >
+    Retrain
+  </button>
 </mat-toolbar>

--- a/src/app/shared/header/header.component.scss
+++ b/src/app/shared/header/header.component.scss
@@ -1,0 +1,9 @@
+.toolbar {
+  display: flex;
+  justify-content: space-between;
+}
+
+button {
+  background-color: #4caf50;
+  color: #ffffff;
+}

--- a/src/app/shared/header/header.component.spec.ts
+++ b/src/app/shared/header/header.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { RouterTestingModule } from "@angular/router/testing";
 import { SharedModule } from "../shared.module";
 
 import { HeaderComponent } from "./header.component";
@@ -9,7 +10,7 @@ describe("HeaderComponent", () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SharedModule],
+      imports: [SharedModule, RouterTestingModule],
     }).compileComponents();
   });
 

--- a/src/app/shared/header/header.component.ts
+++ b/src/app/shared/header/header.component.ts
@@ -1,15 +1,18 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit } from "@angular/core";
+import { Router } from "@angular/router";
 
 @Component({
-  selector: 'app-header',
-  templateUrl: './header.component.html',
-  styleUrls: ['./header.component.scss']
+  selector: "app-header",
+  templateUrl: "./header.component.html",
+  styleUrls: ["./header.component.scss"],
 })
 export class HeaderComponent implements OnInit {
+  constructor(private router: Router) {}
 
-  constructor() { }
+  ngOnInit(): void {}
 
-  ngOnInit(): void {
+  goToCollectingPage() {
+    localStorage.removeItem("modal-files");
+    this.router.navigate(["/"]);
   }
-
 }


### PR DESCRIPTION
Fixes #21  #22 

1:- on thr first time collecting the data we are set a modal-files variable to the local storage and then navigate to the home page. When user close the app and re-open the app it checks if the model-files variable exist in the local Storage it will be redirect to the home page not the collecting page.
2:- add retrain button on the toolbar of header when user click on it will be redirect to the collecting page and remove the local Storage modal-files variable

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests (npm run test & npm run e2e) that prove my fix is effective or that my feature works
